### PR TITLE
Add /go to Dockerfile as safe directory for git

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,5 +1,7 @@
 FROM golang:1.22-bullseye AS base
 
+RUN git config --global --add safe.directory /go
+
 ENV GOCACHE=/go/.go/cache GOPATH=/go/.go/path TZ=Europe/London
 
 RUN GOBIN=/bin go install github.com/cespare/reflex@latest


### PR DESCRIPTION
### What

Jira ticket: https://jira.ons.gov.uk/browse/DIS-1639

It was not possible to run the search stack, using colima, due to a 'dubious ownership' error that was appearing in the docker logs for both the frontend release calendar and the release calendar api. This PR solves the problem in the release calendar api.

### How to review

To test the release calendar api you will also need to switch your frontend release calendar to use this branch (unless it's been merged in already):  https://github.com/ONSdigital/dp-frontend-release-calendar/tree/fix/dubious-ownership-error

Run the search stack using colima, as follows:

- Move to search stack directory and set SERVICE_AUTH_TOKEN to any suitable value from the sandbox service configs
```shell
cd dp-compose/v2/stacks/search
export SERVICE_AUTH_TOKEN=<a value from the sandbox configs>
```

- connect to sandbox
```shell
aws sso login --profile=dp-sandbox
dp remote allow sandbox
```

- Use consul to check the values then port-forward to zebedee e.g.
```shell
dp ssh sandbox 10.30.138.118 -p 8082:10.30.138.118:23244
```

- Use consul to check the values (for 'publishing' not 'web') then port-forward to dataset api e.g.
```shell
dp ssh sandbox 10.30.138.141 -p 22000:10.30.138.141:21785
```

- start colima, using enough memory for the stack NB. use `brew install colima' if it's not currently installed.
```shell
colima start --cpu 4 --memory 8 --disk 100
```

- bring up the auth stack (you may need to do 'make clean' first)
```shell
make up
```

- After some time check to see whether all the services are up and healthy
```shell
make health
```

You should see that all the services are healthy including the release calendar api.

- the following URL should now return empty JSON:
http://localhost:23900/search

For further testing, if desired, you could go to dp-search-reindex-batch, use 'make debug' to run the batch reindex (this runs a little while), and then check that the following contains populated and filtered indexes:

http://localhost:23900/search?uri_prefix=/releases

### Who can review

Anyone but me.