### PR TITLE
upgrade zebedee client to fix auth

### DIFF
--- a/.dis-vulncheck.yml
+++ b/.dis-vulncheck.yml
@@ -1,7 +1,0 @@
-ignore:
-  - id: GO-2026-4883
-    module: github.com/docker/docker
-    reason: No fix available; transitive dependency via dp-component-test -> testcontainers-go; only used for testing, not used by service runtime.
-  - id: GO-2026-4887
-    module: github.com/docker/docker
-    reason: No fix available; transitive dependency via dp-component-test -> testcontainers-go; only used for testing, not used by service runtime.

--- a/api/clients.go
+++ b/api/clients.go
@@ -12,6 +12,6 @@ import (
 
 // ZebedeeClient defines the required methods to talk to Zebedee
 type ZebedeeClient interface {
-	GetRelease(ctx context.Context, userAccessToken, collectionID, lang, uri string) (zebedee.Release, error)
+	GetRelease(ctx context.Context, authToken, collectionID, lang, uri string) (zebedee.Release, error)
 	Checker(ctx context.Context, check *healthcheck.CheckState) error
 }

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/ONSdigital/dp-release-calendar-api
 go 1.26.0
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.267.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.279.0
 	github.com/ONSdigital/dp-component-test v0.23.0
 	github.com/ONSdigital/dp-healthcheck v1.6.4
-	github.com/ONSdigital/dp-net/v3 v3.3.0
+	github.com/ONSdigital/dp-net/v3 v3.11.0
 	github.com/ONSdigital/log.go/v2 v2.4.5
 	github.com/cucumber/godog v0.15.0
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/ONSdigital/dis-redis v0.3.0 h1:aI0d3MsXPmRbe+okYAbrwEGBibhoCw+gfbgtJ3mA11c=
 github.com/ONSdigital/dis-redis v0.3.0/go.mod h1:CLbCwaEfJhifBM7PufwNi0mymys+xM6xNgwhihhSIHQ=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.267.0 h1:bqe1qqVXmwMxKUjly8Fzzlcq5p1rz1PUvQhgEBIF+kA=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.267.0/go.mod h1:bLseTP21r8LCStUEeOdVPyqtrTomOFP/azPjKWW4deA=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.279.0 h1:BQ+8GiomGO33ANQ9XVUVRiXW5zUtf19XLUN4b+httJI=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.279.0/go.mod h1:dTOrseSPzH9WRV/qgNy/zu5BeZWbea02Qz4Z6lvHhFQ=
 github.com/ONSdigital/dp-component-test v0.23.0 h1:alA2MCoWs8O/xQISb3HWxHfk5unZ+M4FSu1gzvaNsm0=
 github.com/ONSdigital/dp-component-test v0.23.0/go.mod h1:GT4g0nvVnyGQZjIf2BasCO5jPn8n8jEXqxKAOIxXNho=
 github.com/ONSdigital/dp-healthcheck v1.6.4 h1:FhWOuVmob36dYq7AzCdbgyf0Vk58IFitSl8y8pWJ8ck=
@@ -10,8 +10,8 @@ github.com/ONSdigital/dp-mocking v0.11.0 h1:laln6e2JD4vtsYbg0cTw9ur1Xf390AUYdd85
 github.com/ONSdigital/dp-mocking v0.11.0/go.mod h1:oHkuukWnURnK7epY5TD5oYVkOwldR2La1D5LQBTxY0A=
 github.com/ONSdigital/dp-mongodb-in-memory v1.8.1 h1:yCz6BfjA0bvesA0JjyBIA6nsOzNquBNS7FQP5pbnZKU=
 github.com/ONSdigital/dp-mongodb-in-memory v1.8.1/go.mod h1:YyTE7QBdV+Fzz5vGnmcPI1nVGCkMcaqsO4TCUlRe6Pc=
-github.com/ONSdigital/dp-net/v3 v3.3.0 h1:NAH9z+nvbJxoK6OnDpOyJJ+52dqBhVtaugk5bqEDt0Y=
-github.com/ONSdigital/dp-net/v3 v3.3.0/go.mod h1:ur4LLCvd2xW2jpa785pElE6HB2bPvszZxdAjqv0XFGg=
+github.com/ONSdigital/dp-net/v3 v3.11.0 h1:oLaP0cFem0KKvxeg9ozPUux5yCGRUWlB+XQPEtzt6yU=
+github.com/ONSdigital/dp-net/v3 v3.11.0/go.mod h1:ur4LLCvd2xW2jpa785pElE6HB2bPvszZxdAjqv0XFGg=
 github.com/ONSdigital/log.go/v2 v2.4.5 h1:LclSJUNHgbhgl386daHXNX9j3LOwXd/AeuiSSfEuclM=
 github.com/ONSdigital/log.go/v2 v2.4.5/go.mod h1:qaWY2DOgD/hIzas3m76WPye1HrrS3RLXQC7erxVL36Y=
 github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 h1:uvdUDbHQHO85qeSydJtItA4T55Pw6BtAejd0APRJOCE=


### PR DESCRIPTION
### What

- upgrade dp-api-clients-go to version where the zebedee client has been modified to fix support for both user and service auth tokens
- updated client interface to reflect above
- cleanup of no -longer-needed vulnerability exceptions

### How to review

Ensure upgrade as expected and tests pass

### Who can review

Anyone