### PR TITLE
Upgrade to use go 1.26.4

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-release-calendar-api

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: 1.26.3-bookworm
 
 inputs:
   - name: dp-release-calendar-api

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-release-calendar-api

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: 1.26.3-bookworm
 
 inputs:
   - name: dp-release-calendar-api

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.26.2-bookworm-golangci-lint-2
+    tag: 1.26.3-bookworm-golangci-lint-2
 
 inputs:
   - name: dp-release-calendar-api

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.26.3-bookworm-golangci-lint-2
+    tag: 1.26.4-bookworm-golangci-lint-2
 
 inputs:
   - name: dp-release-calendar-api

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-release-calendar-api

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: 1.26.3-bookworm
 
 inputs:
   - name: dp-release-calendar-api


### PR DESCRIPTION
### What

Jira ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-4951

The version of go has been increased from 1.26.2 to 1.26.4, to fix audit failures.

NB. Originally it was being upgraded to 1.26.3, hence the Jira ticket.

### How to review

Sense check. Tests pass.

### Who can review

Anyone.